### PR TITLE
Improve time editing with automatic mask

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -3,7 +3,7 @@ import tkinter as tk
 from tkinter import messagebox, ttk
 import vlc
 
-from logic import ChapterManager, fmt_sec, parse_time
+from logic import ChapterManager, fmt_sec, parse_flexible_time
 
 UPDATE_MS = 500  # refresh UI in ms
 
@@ -160,18 +160,36 @@ class ChapterEditor(tk.Frame):
                     self.chaps[idx]["title"] = new_val
             else:
                 try:
-                    sec = parse_time(new_val)
+                    sec = parse_flexible_time(new_val)
                 except ValueError:
-                    messagebox.showerror("Tempo", "Formato hh:mm:ss ou mm:ss")
+                    messagebox.showerror(
+                        "Tempo",
+                        "Formato hh:mm:ss, mm:ss ou somente dígitos",
+                    )
                     return
                 key = "start" if col_idx == 1 else "end"
                 self.chaps[idx][key] = sec
             self._refresh_tree()
             self.manager.save(self.chaps)
 
+        def format_time(_):
+            if col_idx == 0:
+                return
+            digits = "".join(ch for ch in entry.get() if ch.isdigit())[-6:]
+            if len(digits) > 4:
+                val = f"{digits[:-4]}:{digits[-4:-2]}:{digits[-2:]}"
+            elif len(digits) > 2:
+                val = f"{digits[:-2]}:{digits[-2:]}"
+            else:
+                val = digits
+            entry.delete(0, tk.END)
+            entry.insert(0, val)
+            entry.icursor(tk.END)
+
         entry.bind("<Return>", commit)
         entry.bind("<Escape>", lambda *_: entry.destroy())
         entry.bind("<FocusOut>", lambda *_: entry.destroy())
+        entry.bind("<KeyRelease>", format_time)
 
     # ----------- UI loop ----------
     def _update_ui(self):

--- a/logic.py
+++ b/logic.py
@@ -11,7 +11,7 @@ def fmt_sec(sec: int) -> str:
 
 def parse_time(txt: str) -> int:
     """Parse ``hh:mm:ss`` or ``mm:ss`` strings into seconds."""
-    parts = [int(p) for p in txt.strip().split(':')]
+    parts = [int(p) for p in txt.strip().split(":")]
     if len(parts) == 2:
         m, s = parts
         h = 0
@@ -19,6 +19,30 @@ def parse_time(txt: str) -> int:
         h, m, s = parts
     else:
         raise ValueError("Time must be in hh:mm:ss or mm:ss format")
+    return h * 3600 + m * 60 + s
+
+
+def parse_flexible_time(txt: str) -> int:
+    """Parse ``hh:mm:ss``, ``mm:ss`` or plain digits into seconds."""
+    cleaned = txt.strip()
+    if ":" in cleaned:
+        return parse_time(cleaned)
+
+    digits = "".join(ch for ch in cleaned if ch.isdigit())
+    if not digits:
+        raise ValueError("Invalid time")
+
+    digits = digits[-6:]  # keep last 6 digits (hhmmss)
+    if len(digits) <= 2:
+        h, m, s = 0, 0, int(digits)
+    elif len(digits) <= 4:
+        h = 0
+        m = int(digits[:-2])
+        s = int(digits[-2:])
+    else:
+        h = int(digits[:-4])
+        m = int(digits[-4:-2])
+        s = int(digits[-2:])
     return h * 3600 + m * 60 + s
 
 


### PR DESCRIPTION
## Summary
- add `parse_flexible_time` to accept digits without `:`
- bind key events to automatically format time fields while typing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68617c7d92c4832fa56d7b27cb275b18