### PR TITLE
Adiciona menu e configuracoes com atalhos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Video Player/Editor
+
+Aplicativo simples escrito em Python 3.12 que usa `python-vlc` para reprodu\u00e7\u00e3o de v\u00eddeos. Permite adicionar e editar cap\u00edtulos de arquivos MP4.
+
+## Recursos
+
+- Abrir v\u00eddeos e editar cap\u00edtulos
+- Menu para abrir novos arquivos
+- Arquivo `config.json` armazena:
+  - Intervalo de atualiza\u00e7\u00e3o da interface
+  - Tempo dos saltos r\u00e1pidos (curto e longo)
+  - Teclas de atalho para play/pause e avan\u00e7o/retrocesso
+- Bot\u00f5es de avan\u00e7ar/retroceder
+- Tela de configura\u00e7\u00f5es para definir atalhos
+
+Execute `app.py` para iniciar o programa.

--- a/app.py
+++ b/app.py
@@ -1,16 +1,42 @@
 import tkinter as tk
 from tkinter import filedialog
 
-from gui import ChapterEditor
+from config import load_config, save_config
+from gui import ChapterEditor, SettingsWindow
 
 
 def main() -> None:
     root = tk.Tk()
     root.title("Editor de Capítulos")
-    video = filedialog.askopenfilename(filetypes=[("Vídeo MP4", "*.mp4")])
-    if video:
-        ChapterEditor(root, video)
-        root.mainloop()
+
+    config = load_config()
+    editor: ChapterEditor | None = None
+
+    def open_video() -> None:
+        nonlocal editor
+        path = filedialog.askopenfilename(filetypes=[("Vídeo MP4", "*.mp4")])
+        if not path:
+            return
+        if editor:
+            editor.destroy()
+        editor = ChapterEditor(root, path, config)
+
+    def show_settings() -> None:
+        SettingsWindow(root, config, lambda: editor.update_config(config) if editor else None)
+
+    menubar = tk.Menu(root)
+    file_menu = tk.Menu(menubar, tearoff=0)
+    file_menu.add_command(label="Abrir vídeo", command=open_video)
+    file_menu.add_separator()
+    file_menu.add_command(label="Sair", command=root.quit)
+    menubar.add_cascade(label="Arquivo", menu=file_menu)
+
+    menubar.add_command(label="Configurações", command=show_settings)
+    root.config(menu=menubar)
+
+    open_video()
+    root.mainloop()
+    save_config(config)
 
 
 if __name__ == "__main__":

--- a/config.py
+++ b/config.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+CONFIG_PATH = "config.json"
+
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "update_ms": 500,
+    "small_jump": 5,
+    "large_jump": 20,
+    "keys": {
+        "play_pause": "<space>",
+        "back_small": "<Left>",
+        "fwd_small": "<Right>",
+        "back_large": "<Shift-Left>",
+        "fwd_large": "<Shift-Right>",
+    },
+}
+
+
+def _deep_update(base: Dict[str, Any], updates: Dict[str, Any]) -> None:
+    for k, v in updates.items():
+        if isinstance(v, dict) and isinstance(base.get(k), dict):
+            _deep_update(base[k], v)
+        else:
+            base[k] = v
+
+
+def load_config() -> Dict[str, Any]:
+    cfg = DEFAULT_CONFIG.copy()
+    cfg["keys"] = cfg["keys"].copy()
+    if os.path.exists(CONFIG_PATH):
+        with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+            loaded = json.load(fh)
+        _deep_update(cfg, loaded)
+    return cfg
+
+
+def save_config(cfg: Dict[str, Any]) -> None:
+    with open(CONFIG_PATH, "w", encoding="utf-8") as fh:
+        json.dump(cfg, fh, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Resumo
- cria arquivo `config.py` para armazenar intervalos, saltos e atalhos
- adiciona menu principal com abrir vídeo e tela de configurações
- cria janela de configurações para editar tempos e teclas
- inclui botões de avanço e retrocesso configuráveis
- atualiza `README.md`

## Testes
- `black --line-length 120 .`
- `ruff check .`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68619e1e4268832f86bf7ad5afc1abaa