### PR TITLE
Resolve audio de vídeo anterior ao abrir novo

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -176,6 +176,14 @@ class ChapterEditor(tk.Frame):
         self._start_update_loop()
         self._bind_keys()
 
+    def destroy(self) -> None:  # type: ignore[override]
+        """Stop playback and clean up VLC resources."""
+        self._stop_update_loop()
+        self.player.stop()
+        self.player.release()
+        self.vlc.release()
+        super().destroy()
+
     def update_config(self, config: dict) -> None:
         """Apply updated configuration to the editor."""
         self.config = config


### PR DESCRIPTION
## Summary
- libera recursos do VLC ao fechar `ChapterEditor`

## Testing
- `ruff check .`
- `black --line-length 120 .`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6861a121f520832f9270de0e6f560671