### PR TITLE
Melhoria na configuração de atalhos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Aplicativo simples escrito em Python 3.12 que usa `python-vlc` para reprodu\u00e
   - Tempo dos saltos r\u00e1pidos (curto e longo)
   - Teclas de atalho para play/pause e avan\u00e7o/retrocesso
 - Bot\u00f5es de avan\u00e7ar/retroceder
-- Tela de configura\u00e7\u00f5es para definir atalhos
+- Tela de configura\u00e7\u00f5es para definir atalhos (basta pressionar a tecla desejada)
 
 Execute `app.py` para iniciar o programa.

--- a/gui.py
+++ b/gui.py
@@ -39,13 +39,27 @@ class SettingsWindow(tk.Toplevel):
         for i, (key, lbl) in enumerate(labels, start=3):
             tk.Label(self, text=lbl).grid(row=i, column=0, sticky="e")
             var = tk.StringVar(value=config.get("keys", {}).get(key, ""))
-            tk.Entry(self, textvariable=var, width=15).grid(row=i, column=1)
+            ent = tk.Entry(self, textvariable=var, width=15)
+            ent.grid(row=i, column=1)
+            ent.bind("<Key>", lambda e, v=var: self._capture_key(e, v))
             self.key_vars[key] = var
 
         tk.Button(self, text="Salvar", command=self.save).grid(row=i + 1, column=0, columnspan=2, pady=5)
 
         self.resizable(False, False)
         self.grab_set()
+
+    def _capture_key(self, event: tk.Event, var: tk.StringVar) -> str:
+        """Capture pressed key and save as Tk binding string."""
+        mods = []
+        if event.state & 0x4:
+            mods.append("Control")
+        if event.state & 0x1:
+            mods.append("Shift")
+        if event.state & 0x8:
+            mods.append("Alt")
+        var.set("<" + "-".join(mods + [event.keysym]) + ">")
+        return "break"
 
     def save(self) -> None:
         """Persist the configuration and notify the caller."""


### PR DESCRIPTION
## Resumo
- permitir captura direta de teclas nas configurações
- atualizar documentação com a nova forma de definir atalhos

## Testes
- `black --line-length 120 .`
- `ruff check .`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6861a3ddd7b0832fa477ce03b0fbd34e