### PR TITLE
Implementação de subcapítulos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Aplicativo simples escrito em Python 3.12 que usa `python-vlc` para reprodu\u00e
 ## Recursos
 
 - Abrir v\u00eddeos e editar cap\u00edtulos
+- Cada capítulo pode ter subitens que herdam o tempo do pai
 - Aba adicional para editar lista de casting
 - Menu para abrir novos arquivos
 - Arquivo `config.json` armazena:


### PR DESCRIPTION
## Resumo
- permite hierarquia de capítulos com subcapítulos
- adiciona botão para criar subcapítulos
- salva e edita subcapítulos na mesma árvore
- documenta funcionalidade no README

## Testes
- `black --line-length 120 .`
- `ruff check .`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6861e693f8ac832fbbfc8b2f22ede25a